### PR TITLE
Fix typo in understanding-github-code-search-syntax.md

### DIFF
--- a/content/search-github/github-code-search/understanding-github-code-search-syntax.md
+++ b/content/search-github/github-code-search/understanding-github-code-search-syntax.md
@@ -75,7 +75,7 @@ To search for documents containing either one term or the other, you can use the
 sparse OR index
 ```
 
-To exclude files from your search results, you can use the `NOT` operator. For example, to exclude file in the `__testing__` directory, you can search:
+To exclude files from your search results, you can use the `NOT` operator. For example, to exclude files in the `__testing__` directory, you can search:
 
 ```
 "fatal error" NOT path:__testing__


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Word "file" in the code search syntax docs should be "files"

Closes:  [https://github.com/github/docs/issues/27373](https://github.com/github/docs/issues/27373)

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Line 78, added an "s".

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ X ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ X ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
